### PR TITLE
refactor: skip signal handler cleanup when registration was skipped

### DIFF
--- a/src/auto_dev_loop/main.py
+++ b/src/auto_dev_loop/main.py
@@ -231,9 +231,11 @@ async def daemon_loop(config: Config, *, once: bool = False) -> None:
             shutdown_event.set()
 
     loop = asyncio.get_running_loop()
+    handlers_registered = False
     try:
         for sig in (signal.SIGTERM, signal.SIGINT):
             loop.add_signal_handler(sig, _request_shutdown)
+        handlers_registered = True
     except NotImplementedError:
         log.warning(
             "Signal handlers not supported on this event loop; "
@@ -258,13 +260,14 @@ async def daemon_loop(config: Config, *, once: bool = False) -> None:
 
             await _interruptible_sleep(poll_interval, shutdown_event)
     finally:
-        for sig in (signal.SIGTERM, signal.SIGINT):
-            try:
-                loop.remove_signal_handler(sig)
-            except (NotImplementedError, RuntimeError) as exc:
-                log.debug("Could not remove signal handler for %s: %s", sig, exc)
-            except Exception:
-                log.exception("Unexpected error removing signal handler for %s", sig)
+        if handlers_registered:
+            for sig in (signal.SIGTERM, signal.SIGINT):
+                try:
+                    loop.remove_signal_handler(sig)
+                except (NotImplementedError, RuntimeError) as exc:
+                    log.debug("Could not remove signal handler for %s: %s", sig, exc)
+                except Exception:
+                    log.exception("Unexpected error removing signal handler for %s", sig)
         await drain_tasks(state)
         await store.close()
 


### PR DESCRIPTION
## Summary

- Guard `remove_signal_handler` calls with a `handlers_registered` flag in the `finally` block
- When `add_signal_handler` raises `NotImplementedError` (e.g. Windows/proactor loops), cleanup is now skipped entirely instead of attempting to remove handlers that were never installed

## Motivation

Previously, if signal handler registration failed with `NotImplementedError`, the `finally` block would still iterate over both signals and attempt to call `remove_signal_handler` — each raising `NotImplementedError` again, caught and emitted as spurious debug log entries on every daemon shutdown.

## Test plan

- [ ] All existing tests pass (`uv run pytest`)
- [ ] No behaviour change on Unix (handlers still cleaned up on normal exit)
- [ ] On unsupported loops, no spurious debug log messages during shutdown