### PR TITLE
fix: validate empty repo name in repo_slug()

### DIFF
--- a/src/auto_dev_loop/_paths.py
+++ b/src/auto_dev_loop/_paths.py
@@ -12,7 +12,7 @@ def repo_slug(owner: str, repo: str) -> str:
     Uses ``/`` as separator so that owner and repo become separate path
     segments, avoiding ambiguity when either component contains ``-``.
 
-    Raises :class:`ValueError` if *owner* is empty after stripping.
+    Raises :class:`ValueError` if *owner* or *repo* is empty after stripping.
     """
     clean_owner = owner.strip().replace("/", "-").replace("\\", "-")
     clean_repo = repo.strip().replace("/", "-").replace("\\", "-")
@@ -20,6 +20,11 @@ def repo_slug(owner: str, repo: str) -> str:
         raise ValueError(
             f"Cannot derive a repo slug: owner is empty for repo '{repo}'. "
             "Set the explicit 'owner' field in your repo config."
+        )
+    if not clean_repo:
+        raise ValueError(
+            f"Cannot derive a repo slug: repo name is empty (owner='{owner}'). "
+            "Check the 'path' field in your repo config."
         )
     return f"{clean_owner}/{clean_repo}"
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -36,6 +36,16 @@ def test_repo_slug_raises_on_whitespace_only_owner():
         repo_slug("  ", "my-repo")
 
 
+def test_repo_slug_raises_on_empty_repo():
+    with pytest.raises(ValueError, match="repo name is empty"):
+        repo_slug("my-owner", "")
+
+
+def test_repo_slug_raises_on_whitespace_only_repo():
+    with pytest.raises(ValueError, match="repo name is empty"):
+        repo_slug("my-owner", "  ")
+
+
 def test_repo_state_dir_returns_expected_path():
     result = repo_state_dir("rube-de/adl-agent-sdk")
     assert result == ADL_HOME / "repos" / "rube-de" / "adl-agent-sdk"


### PR DESCRIPTION
## Summary

- Add symmetric `ValueError` check for empty repo name in `repo_slug()`, matching the existing owner validation
- Prevents silent `state.db` collision at the owner-level directory when `_get_repo_name` returns an empty string (e.g. `path="/"`)

Addresses [review comment](https://github.com/rube-de/adl-agent-sdk/pull/32#discussion_r2898086404) from PR #32.

## Test plan

- [x] `test_repo_slug_raises_on_empty_repo` — empty string raises ValueError
- [x] `test_repo_slug_raises_on_whitespace_only_repo` — whitespace-only raises ValueError
- [x] All existing path tests pass (11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened repository path validation with more informative error messages that clearly communicate when repository names are empty or invalid, guiding users to review their configuration.

* **Tests**
  * Added validation tests to ensure empty and whitespace-only repository names are properly rejected with clear, consistent error messages for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->