### PR TITLE
chore: add missing test coverage for adl init wizard

### DIFF
--- a/tests/test_init_wizard.py
+++ b/tests/test_init_wizard.py
@@ -123,8 +123,9 @@ def test_run_init_wizard_group_chat_without_topics(tmp_path: Path, monkeypatch) 
 
 
 def test_build_config_data_hardcoded_token() -> None:
+    test_bot_token = "test-bot-token"  # noqa: S105
     config_data = build_config_data(
-        bot_token="my-secret-token",
+        bot_token=test_bot_token,
         chat_id=12345,
         chat_type="private",
         use_topics=False,
@@ -133,25 +134,27 @@ def test_build_config_data_hardcoded_token() -> None:
         defaults=dict(DEFAULT_TUNABLE_DEFAULTS),
     )
 
-    assert config_data["telegram"]["bot_token"] == "my-secret-token"
+    assert config_data["telegram"]["bot_token"] == test_bot_token
 
 
 def test_run_init_wizard_hardcoded_token(tmp_path: Path, monkeypatch, capsys) -> None:
+    test_bot_token = "test-bot-token"  # noqa: S105
     config_path = tmp_path / "config.yaml"
 
-    _patch_prompt_sequence(monkeypatch, ["my-secret-token", 424242])
+    _patch_prompt_sequence(monkeypatch, [test_bot_token, 424242])
     # use_topics=False, use_env_token=False, model_defaults=True, daemon_defaults=True
     _patch_confirm_sequence(monkeypatch, [False, False, True, True])
 
     run_init_wizard(config_path)
 
     cfg_yaml = yaml.safe_load(config_path.read_text())
-    assert cfg_yaml["telegram"]["bot_token"] == "my-secret-token"
+    assert cfg_yaml["telegram"]["bot_token"] == test_bot_token
 
     cfg = load_config(config_path)
     assert cfg.telegram.chat_id == 424242
 
     captured = capsys.readouterr()
+    assert "Config written to" in captured.out
     assert TELEGRAM_BOT_TOKEN_ENV not in captured.out
 
 


### PR DESCRIPTION
## Summary

- Adds 6 tests covering gaps identified in the PR #30 review
- Hardcoded token path (`use_env_token=False`) — unit + e2e with no env reminder assertion
- Validation failure path — `Exit(1)` raised, config file not written
- Custom model roles — user declines defaults, custom names in output
- Custom daemon defaults — user declines defaults, custom values in output  
- Overwrite-accept — existing file replaced with new config
- `_prompt_required` retry — empty/whitespace input retried until valid

## Test plan

- [x] All 6 new tests pass (`tests/test_init_wizard.py` — 11 total)
- [x] Full suite passes (431 tests, 2.71s)
- [x] No implementation code modified

Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for the initialization wizard covering hardcoded and path-based token handling, validation failure paths, custom model roles, custom daemon defaults, overwrite-accept flow for existing configs, and input-retry behavior on empty responses.

Note: QA/test improvements only; no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->