### PR TITLE
feat: add explicit handling for blocked, clarification_needed, and max_iterations verdicts

### DIFF
--- a/src/auto_dev_loop/workflow_engine.py
+++ b/src/auto_dev_loop/workflow_engine.py
@@ -8,6 +8,7 @@ engine testable without SDK dependencies.
 from __future__ import annotations
 
 import logging
+import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
@@ -29,6 +30,19 @@ from .workflow_conditions import CONDITIONS  # noqa: F401 — re-exported as pub
 from .workflow_loader import StageConfig, WorkflowConfig
 
 log = logging.getLogger(__name__)
+
+_VERDICT_MARKER_RE = re.compile(r"^\s*<<<VERDICT:[A-Z_]+>>>\s*$", re.MULTILINE)
+
+_ESCALATION_REASONS: dict[VerdictStatus, str] = {
+    VerdictStatus.BLOCKED: "blocked",
+    VerdictStatus.CLARIFICATION_NEEDED: "clarification_needed",
+    VerdictStatus.MAX_ITERATIONS: "agent_max_iterations",
+}
+
+
+def _strip_verdict_markers(output: str) -> str:
+    """Remove verdict marker lines from agent output for clean storage."""
+    return _VERDICT_MARKER_RE.sub("", output).strip()
 
 
 class StageDispatcher(ABC):
@@ -223,26 +237,20 @@ async def execute_workflow(
                 "security_veto",
             )
             if human_result == "approve":
-                stage_outputs[stage.ref] = output
+                stage_outputs[stage.ref] = _strip_verdict_markers(output)
                 stage_idx += 1
                 continue
             return WorkflowResult(status=WorkflowStatus.VETOED, stage=stage.ref)
 
         if verdict.status in (VerdictStatus.BLOCKED, VerdictStatus.CLARIFICATION_NEEDED, VerdictStatus.MAX_ITERATIONS):
-            # "agent_max_iterations" (not "iteration_cap") distinguishes
-            # agent-reported limit from engine-enforced maxIterations exhaustion.
-            reason = (
-                "agent_max_iterations"
-                if verdict.status == VerdictStatus.MAX_ITERATIONS
-                else verdict.status.value
-            )
+            reason = _ESCALATION_REASONS[verdict.status]
             human_result = await dispatcher.escalate_to_human(
                 issue, stage,
                 ReviewVerdict(approved=False, feedback=verdict.feedback),
                 reason,
             )
             if human_result == "approve":
-                stage_outputs[stage.ref] = output
+                stage_outputs[stage.ref] = _strip_verdict_markers(output)
                 stage_idx += 1
                 continue
             return WorkflowResult(status=WorkflowStatus.ESCALATED, stage=stage.ref)

--- a/src/auto_dev_loop/workflow_engine.py
+++ b/src/auto_dev_loop/workflow_engine.py
@@ -228,6 +228,25 @@ async def execute_workflow(
                 continue
             return WorkflowResult(status=WorkflowStatus.VETOED, stage=stage.ref)
 
+        if verdict.status in (VerdictStatus.BLOCKED, VerdictStatus.CLARIFICATION_NEEDED, VerdictStatus.MAX_ITERATIONS):
+            # "agent_max_iterations" (not "iteration_cap") distinguishes
+            # agent-reported limit from engine-enforced maxIterations exhaustion.
+            reason = (
+                "agent_max_iterations"
+                if verdict.status == VerdictStatus.MAX_ITERATIONS
+                else verdict.status.value
+            )
+            human_result = await dispatcher.escalate_to_human(
+                issue, stage,
+                ReviewVerdict(approved=False, feedback=verdict.feedback),
+                reason,
+            )
+            if human_result == "approve":
+                stage_outputs[stage.ref] = output
+                stage_idx += 1
+                continue
+            return WorkflowResult(status=WorkflowStatus.ESCALATED, stage=stage.ref)
+
         if stage.loopTarget:
             # Jump back to the target stage; track feedback for context
             target_idx = _find_stage_index(workflow, stage.loopTarget)

--- a/src/auto_dev_loop/workflow_engine.py
+++ b/src/auto_dev_loop/workflow_engine.py
@@ -42,7 +42,9 @@ _ESCALATION_REASONS: dict[VerdictStatus, str] = {
 
 def _strip_verdict_markers(output: str) -> str:
     """Remove verdict marker lines from agent output for clean storage."""
-    return _VERDICT_MARKER_RE.sub("", output).strip()
+    stripped = _VERDICT_MARKER_RE.sub("", output)
+    stripped = re.sub(r"\n{3,}", "\n\n", stripped)
+    return stripped.strip()
 
 
 class StageDispatcher(ABC):
@@ -195,7 +197,7 @@ async def execute_workflow(
                 "iteration_cap",
             )
             if human_result == "approve":
-                stage_outputs[stage.ref] = last_output
+                stage_outputs[stage.ref] = _strip_verdict_markers(last_output)
                 stage_idx += 1
             else:
                 return WorkflowResult(status=WorkflowStatus.ESCALATED, stage=stage.ref)

--- a/tests/test_workflow_engine.py
+++ b/tests/test_workflow_engine.py
@@ -535,3 +535,51 @@ async def test_max_iterations_verdict_human_approves():
     )
     result = await execute_workflow(wf, _issue(), MaxIterApproveDispatcher({}))
     assert result.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_blocked_verdict_no_loop_target_escalates():
+    """BLOCKED on a stage without loopTarget should escalate, not loop indefinitely."""
+    escalation_reasons = []
+
+    class BlockedDispatcher(FakeDispatcher):
+        async def dispatch_single(self, stage, issue, prior_outputs):
+            if stage.ref == "dev":
+                return VERDICT_BLOCKED
+            return VERDICT_APPROVED
+
+        async def escalate_to_human(self, issue, stage, verdict, reason):
+            escalation_reasons.append(reason)
+            return "reject"
+
+    wf = _workflow(StageConfig(ref="dev", agent="developer"))
+    result = await execute_workflow(wf, _issue(), BlockedDispatcher({}))
+    assert result.status == "escalated"
+    assert result.stage == "dev"
+    assert escalation_reasons == ["blocked"]
+
+
+@pytest.mark.asyncio
+async def test_approved_escalation_strips_verdict_markers():
+    """Approved BLOCKED output stored in stage_outputs should not contain verdict markers."""
+    stored_outputs = {}
+
+    class CapturingDispatcher(FakeDispatcher):
+        async def dispatch_single(self, stage, issue, prior_outputs):
+            stored_outputs.update(prior_outputs)
+            if stage.ref == "dev":
+                return f"I'm blocked on credentials\n\n{VERDICT_BLOCKED}"
+            return VERDICT_APPROVED
+
+        async def escalate_to_human(self, issue, stage, verdict, reason):
+            return "approve"
+
+    wf = _workflow(
+        StageConfig(ref="dev", agent="developer"),
+        StageConfig(ref="review", agent="reviewer"),
+    )
+    result = await execute_workflow(wf, _issue(), CapturingDispatcher({}))
+    assert result.status == "completed"
+    # The review stage should see dev output without the verdict marker
+    assert "<<<VERDICT:BLOCKED>>>" not in stored_outputs.get("dev", "")
+    assert "I'm blocked on credentials" in stored_outputs.get("dev", "")

--- a/tests/test_workflow_engine.py
+++ b/tests/test_workflow_engine.py
@@ -13,6 +13,7 @@ from auto_dev_loop.models import (
     VERDICT_APPROVED, VERDICT_NEEDS_REVISION, VERDICT_VETOED, VERDICT_TESTS_PASSING,
     VERDICT_PLAN_READY, VERDICT_IMPLEMENTATION_COMPLETE, VERDICT_FIXES_APPLIED,
     VERDICT_FEEDBACK_APPLIED, APPROVED_MARKERS,
+    VERDICT_BLOCKED, VERDICT_CLARIFICATION_NEEDED, VERDICT_MAX_ITERATIONS,
 )
 from auto_dev_loop.workflow_loader import WorkflowConfig, StageConfig
 
@@ -390,3 +391,147 @@ def test_parse_verdict_rejects_bare_needs_revision_in_untrusted_data():
     output = f"The old code checked for NEEDS_REVISION\n\n{VERDICT_APPROVED}"
     verdict = _parse_verdict(output)
     assert verdict.status == "approved"
+
+
+# --- Explicit verdict handling tests ---
+
+@pytest.mark.asyncio
+async def test_blocked_verdict_escalates():
+    """BLOCKED verdict should trigger human escalation, not fall through to loopTarget."""
+    escalation_reasons = []
+
+    class BlockedDispatcher(FakeDispatcher):
+        async def dispatch_single(self, stage, issue, prior_outputs):
+            if stage.ref == "dev":
+                return VERDICT_BLOCKED
+            return VERDICT_APPROVED
+
+        async def escalate_to_human(self, issue, stage, verdict, reason):
+            escalation_reasons.append(reason)
+            return "reject"
+
+    wf = _workflow(
+        StageConfig(ref="plan", agent="architect"),
+        StageConfig(ref="dev", agent="developer", loopTarget="plan", maxIterations=3),
+    )
+    result = await execute_workflow(wf, _issue(), BlockedDispatcher({}))
+    assert result.status == "escalated"
+    assert result.stage == "dev"
+    assert escalation_reasons == ["blocked"]
+
+
+@pytest.mark.asyncio
+async def test_blocked_verdict_human_approves():
+    """BLOCKED verdict with human approval should continue the workflow."""
+
+    class BlockedApproveDispatcher(FakeDispatcher):
+        async def dispatch_single(self, stage, issue, prior_outputs):
+            if stage.ref == "dev":
+                return VERDICT_BLOCKED
+            return VERDICT_APPROVED
+
+        async def escalate_to_human(self, issue, stage, verdict, reason):
+            return "approve"
+
+    wf = _workflow(
+        StageConfig(ref="plan", agent="architect"),
+        StageConfig(ref="dev", agent="developer", loopTarget="plan", maxIterations=3),
+    )
+    result = await execute_workflow(wf, _issue(), BlockedApproveDispatcher({}))
+    assert result.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_clarification_needed_verdict_escalates():
+    """CLARIFICATION_NEEDED verdict should trigger human escalation."""
+    escalation_reasons = []
+
+    class ClarificationDispatcher(FakeDispatcher):
+        async def dispatch_single(self, stage, issue, prior_outputs):
+            if stage.ref == "dev":
+                return VERDICT_CLARIFICATION_NEEDED
+            return VERDICT_APPROVED
+
+        async def escalate_to_human(self, issue, stage, verdict, reason):
+            escalation_reasons.append(reason)
+            return "reject"
+
+    wf = _workflow(
+        StageConfig(ref="plan", agent="architect"),
+        StageConfig(ref="dev", agent="developer", loopTarget="plan", maxIterations=3),
+    )
+    result = await execute_workflow(wf, _issue(), ClarificationDispatcher({}))
+    assert result.status == "escalated"
+    assert result.stage == "dev"
+    assert escalation_reasons == ["clarification_needed"]
+
+
+@pytest.mark.asyncio
+async def test_clarification_needed_verdict_human_approves():
+    """CLARIFICATION_NEEDED verdict with human approval should continue."""
+
+    class ClarificationApproveDispatcher(FakeDispatcher):
+        async def dispatch_single(self, stage, issue, prior_outputs):
+            if stage.ref == "dev":
+                return VERDICT_CLARIFICATION_NEEDED
+            return VERDICT_APPROVED
+
+        async def escalate_to_human(self, issue, stage, verdict, reason):
+            return "approve"
+
+    wf = _workflow(
+        StageConfig(ref="plan", agent="architect"),
+        StageConfig(ref="dev", agent="developer", loopTarget="plan", maxIterations=3),
+    )
+    result = await execute_workflow(wf, _issue(), ClarificationApproveDispatcher({}))
+    assert result.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_max_iterations_verdict_escalates_immediately():
+    """MAX_ITERATIONS verdict should bypass loopTarget and escalate immediately."""
+    call_count = {"plan": 0, "dev": 0}
+    escalation_reasons = []
+
+    class MaxIterDispatcher(FakeDispatcher):
+        async def dispatch_single(self, stage, issue, prior_outputs):
+            call_count[stage.ref] = call_count.get(stage.ref, 0) + 1
+            if stage.ref == "dev":
+                return VERDICT_MAX_ITERATIONS
+            return VERDICT_APPROVED
+
+        async def escalate_to_human(self, issue, stage, verdict, reason):
+            escalation_reasons.append(reason)
+            return "reject"
+
+    wf = _workflow(
+        StageConfig(ref="plan", agent="architect"),
+        StageConfig(ref="dev", agent="developer", loopTarget="plan", maxIterations=3),
+    )
+    result = await execute_workflow(wf, _issue(), MaxIterDispatcher({}))
+    assert result.status == "escalated"
+    assert result.stage == "dev"
+    assert escalation_reasons == ["agent_max_iterations"]
+    # plan should only be called ONCE — no loopTarget jump-back
+    assert call_count["plan"] == 1
+
+
+@pytest.mark.asyncio
+async def test_max_iterations_verdict_human_approves():
+    """MAX_ITERATIONS verdict with human approval should continue."""
+
+    class MaxIterApproveDispatcher(FakeDispatcher):
+        async def dispatch_single(self, stage, issue, prior_outputs):
+            if stage.ref == "dev":
+                return VERDICT_MAX_ITERATIONS
+            return VERDICT_APPROVED
+
+        async def escalate_to_human(self, issue, stage, verdict, reason):
+            return "approve"
+
+    wf = _workflow(
+        StageConfig(ref="plan", agent="architect"),
+        StageConfig(ref="dev", agent="developer", loopTarget="plan", maxIterations=3),
+    )
+    result = await execute_workflow(wf, _issue(), MaxIterApproveDispatcher({}))
+    assert result.status == "completed"

--- a/tests/test_workflow_engine.py
+++ b/tests/test_workflow_engine.py
@@ -583,3 +583,28 @@ async def test_approved_escalation_strips_verdict_markers():
     # The review stage should see dev output without the verdict marker
     assert "<<<VERDICT:BLOCKED>>>" not in stored_outputs.get("dev", "")
     assert "I'm blocked on credentials" in stored_outputs.get("dev", "")
+
+
+@pytest.mark.asyncio
+async def test_vetoed_verdict_human_approves_strips_marker():
+    """Approved VETOED output stored in stage_outputs should not contain verdict markers."""
+    stored_outputs = {}
+
+    class VetoApproveCapturing(FakeDispatcher):
+        async def dispatch_single(self, stage, issue, prior_outputs):
+            stored_outputs.update(prior_outputs)
+            if stage.ref == "security":
+                return f"Deployment blocked by policy\n\n{VERDICT_VETOED}"
+            return VERDICT_APPROVED
+
+        async def escalate_to_human(self, issue, stage, verdict, reason):
+            return "approve"
+
+    wf = _workflow(
+        StageConfig(ref="security", agent="sec_reviewer", canVeto=True),
+        StageConfig(ref="deploy", agent="deployer"),
+    )
+    result = await execute_workflow(wf, _issue(), VetoApproveCapturing({}))
+    assert result.status == "completed"
+    assert "<<<VERDICT:VETOED>>>" not in stored_outputs.get("security", "")
+    assert "Deployment blocked by policy" in stored_outputs.get("security", "")


### PR DESCRIPTION
## Summary

- Add explicit verdict branches in `execute_workflow()` for `BLOCKED`, `CLARIFICATION_NEEDED`, and `MAX_ITERATIONS` statuses
- All three now trigger immediate human escalation via `dispatcher.escalate_to_human()` instead of falling through as generic rejections
- `MAX_ITERATIONS` bypasses `loopTarget` and escalates immediately with reason `"agent_max_iterations"` (distinct from engine-enforced `"iteration_cap"`)
- If human approves, stage advances normally; if human rejects, workflow returns `ESCALATED`

Closes #39

## Test plan

- [x] 6 new tests: 2 per verdict status (escalate + human-approve paths)
- [x] `test_blocked_verdict_escalates` — verifies reason string is `"blocked"`
- [x] `test_clarification_needed_verdict_escalates` — verifies reason string is `"clarification_needed"`
- [x] `test_max_iterations_verdict_escalates_immediately` — verifies no loopTarget jump-back (`plan` called only once)
- [x] All 456 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow now recognizes three new verdict states (BLOCKED, CLARIFICATION_NEEDED, MAX_ITERATIONS) and escalates them to human reviewers; approval advances execution, rejection continues escalation.

* **Behavior Change**
  * Agent outputs are cleaned to remove embedded verdict markers before being stored or passed to the next stage.

* **Tests**
  * Tests expanded to cover new verdicts, escalation/approval flows, loop/iteration interactions, and marker-stripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->