### PR TITLE
fix: release lock before RetryAfter sleep in _resolve_thread_id

### DIFF
--- a/src/auto_dev_loop/telegram/__init__.py
+++ b/src/auto_dev_loop/telegram/__init__.py
@@ -77,15 +77,16 @@ class TelegramBot:
         if repo in self._thread_cache:
             return self._thread_cache[repo]  # may be None (cached failure)
         lock = self._thread_locks.setdefault(repo, asyncio.Lock())
+        retry_after: int | None = None
         async with lock:
+            if repo in self._thread_cache:
+                return self._thread_cache[repo]
+            if self._store:
+                stored = await self._store.get_thread_id(repo)
+                if stored is not None:
+                    self._thread_cache[repo] = stored
+                    return stored
             try:
-                if repo in self._thread_cache:
-                    return self._thread_cache[repo]
-                if self._store:
-                    stored = await self._store.get_thread_id(repo)
-                    if stored is not None:
-                        self._thread_cache[repo] = stored
-                        return stored
                 # Note: create_forum_topic intentionally bypasses the
                 # rate-limited TelegramClient. Topic creation is a
                 # once-per-repo operation (cached immediately), and
@@ -93,23 +94,35 @@ class TelegramBot:
                 result = await self._api.create_forum_topic(self._chat_id, repo)
                 return await self._cache_and_store_thread(repo, result.message_thread_id)
             except RetryAfter as exc:
-                log.warning(
-                    "Rate-limited creating topic for %s, retrying after %ss",
-                    repo, exc.retry_after,
-                )
-                await asyncio.sleep(exc.retry_after)
-                try:
-                    result = await self._api.create_forum_topic(self._chat_id, repo)
-                except (BotApiError, RetryAfter, httpx.HTTPError, OSError, ValueError) as retry_exc:
-                    log.warning("Retry failed for %s: %s", repo, retry_exc)
-                    self._thread_cache[repo] = None
-                    return None
-                return await self._cache_and_store_thread(repo, result.message_thread_id)
+                retry_after = exc.retry_after
             except (BotApiError, httpx.HTTPError, OSError, ValueError) as exc:
                 log.warning(
                     "Failed to create forum topic for %s, sending without topic: %s",
                     repo, exc,
                 )
+                self._thread_cache[repo] = None
+                return None
+
+        if retry_after is None:
+            return None  # all non-RetryAfter paths return inside the lock
+
+        # Lock released — sleep without blocking other callers
+        log.warning(
+            "Rate-limited creating topic for %s, retrying after %ss",
+            repo, retry_after,
+        )
+        await asyncio.sleep(retry_after)
+
+        # Re-acquire lock for retry
+        async with lock:
+            # Double-check: another caller may have succeeded during our sleep
+            if repo in self._thread_cache:
+                return self._thread_cache[repo]
+            try:
+                result = await self._api.create_forum_topic(self._chat_id, repo)
+                return await self._cache_and_store_thread(repo, result.message_thread_id)
+            except (BotApiError, RetryAfter, httpx.HTTPError, OSError, ValueError) as retry_exc:
+                log.warning("Retry failed for %s: %s", repo, retry_exc)
                 self._thread_cache[repo] = None
                 return None
 

--- a/src/auto_dev_loop/telegram/__init__.py
+++ b/src/auto_dev_loop/telegram/__init__.py
@@ -103,7 +103,8 @@ class TelegramBot:
                 self._thread_cache[repo] = None
                 return None
 
-        assert retry_after is not None, "all non-RetryAfter paths return inside the lock"
+        if retry_after is None:  # pragma: no cover — unreachable; all non-RetryAfter paths return inside the lock
+            return None
 
         # Lock released — sleep without blocking other callers
         log.warning(

--- a/src/auto_dev_loop/telegram/__init__.py
+++ b/src/auto_dev_loop/telegram/__init__.py
@@ -103,8 +103,7 @@ class TelegramBot:
                 self._thread_cache[repo] = None
                 return None
 
-        if retry_after is None:
-            return None  # all non-RetryAfter paths return inside the lock
+        assert retry_after is not None, "all non-RetryAfter paths return inside the lock"
 
         # Lock released — sleep without blocking other callers
         log.warning(

--- a/src/auto_dev_loop/telegram/bot_api.py
+++ b/src/auto_dev_loop/telegram/bot_api.py
@@ -20,7 +20,7 @@ class HttpBotClient:
         parsed = msgspec.json.decode(resp.content, type=BotApiResponse)
         if not parsed.ok:
             if parsed.error_code == 429:
-                retry_after = parsed.parameters.retry_after if parsed.parameters else 30
+                retry_after = (parsed.parameters.retry_after if parsed.parameters else None) or 30
                 raise RetryAfter(retry_after)
             raise BotApiError(parsed.error_code, parsed.description)
         return parsed

--- a/tests/test_telegram_topics.py
+++ b/tests/test_telegram_topics.py
@@ -435,11 +435,11 @@ async def test_resolve_thread_releases_lock_during_retry_sleep(topics_config, st
             # and succeed while the first caller is sleeping
             task2 = asyncio.create_task(bot._resolve_thread_id(sample_issue.repo))
             # Give task2 a chance to complete (it should succeed quickly)
-            done, pending = await asyncio.wait({task2}, timeout=0.5)
-            assert task2 in done, "Second caller was blocked by lock held during sleep"
-
-            # Now release the first caller's sleep
-            sleep_released.set()
+            done, _pending = await asyncio.wait({task2}, timeout=0.5)
+            try:
+                assert task2 in done, "Second caller was blocked by lock held during sleep"
+            finally:
+                sleep_released.set()
             result1 = await task1
 
     result2 = task2.result()

--- a/tests/test_telegram_topics.py
+++ b/tests/test_telegram_topics.py
@@ -400,3 +400,77 @@ def test_use_topics_requires_state_store(topics_config):
     """use_topics=True without a StateStore should raise ValueError."""
     with pytest.raises(ValueError, match="StateStore is required"):
         TelegramBot(topics_config, store=None)
+
+
+# --- Concurrency / lock-during-sleep tests ---
+
+
+@pytest.mark.asyncio
+async def test_resolve_thread_releases_lock_during_retry_sleep(topics_config, state_store, sample_issue):
+    """Lock must be released during RetryAfter sleep so other callers aren't blocked."""
+    bot = TelegramBot(topics_config, store=state_store)
+    sleep_entered = asyncio.Event()
+    sleep_released = asyncio.Event()
+
+    async def mock_sleep(seconds):
+        sleep_entered.set()
+        await sleep_released.wait()
+
+    call_count = 0
+
+    async def mock_create_topic(chat_id, name):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RetryAfter(30)
+        return ForumTopic(message_thread_id=555, name=name)
+
+    with patch.object(bot._api, "create_forum_topic", side_effect=mock_create_topic):
+        with patch("auto_dev_loop.telegram.asyncio.sleep", side_effect=mock_sleep):
+            # Start first caller — it will hit RetryAfter and enter sleep
+            task1 = asyncio.create_task(bot._resolve_thread_id(sample_issue.repo))
+            await sleep_entered.wait()
+
+            # Second caller should NOT be blocked — it should be able to acquire the lock
+            # and succeed while the first caller is sleeping
+            task2 = asyncio.create_task(bot._resolve_thread_id(sample_issue.repo))
+            # Give task2 a chance to complete (it should succeed quickly)
+            done, pending = await asyncio.wait({task2}, timeout=0.5)
+            assert task2 in done, "Second caller was blocked by lock held during sleep"
+
+            # Now release the first caller's sleep
+            sleep_released.set()
+            result1 = await task1
+
+    result2 = task2.result()
+    assert result2 == 555
+    # Both callers should get the same thread ID
+    assert result1 == 555
+
+
+@pytest.mark.asyncio
+async def test_resolve_thread_checks_cache_after_reacquire(topics_config, state_store, sample_issue):
+    """After re-acquiring lock post-sleep, must check cache before retrying API call."""
+    bot = TelegramBot(topics_config, store=state_store)
+    sleep_released = asyncio.Event()
+
+    async def mock_sleep(seconds):
+        # Simulate another caller populating the cache during our sleep
+        bot._thread_cache[sample_issue.repo] = 999
+        sleep_released.set()
+
+    with patch.object(
+        bot._api, "create_forum_topic",
+        new_callable=AsyncMock,
+        side_effect=[
+            RetryAfter(1),
+            # This second call should NOT happen if cache is checked
+            ForumTopic(message_thread_id=555, name="owner/repo"),
+        ],
+    ) as mock_create, patch("auto_dev_loop.telegram.asyncio.sleep", side_effect=mock_sleep):
+        thread_id = await bot._resolve_thread_id(sample_issue.repo)
+
+    # Should use the cached value (999), not retry the API call
+    assert thread_id == 999
+    # create_forum_topic should only be called once (the initial attempt that raised RetryAfter)
+    assert mock_create.await_count == 1


### PR DESCRIPTION
## Summary

- Refactored `_resolve_thread_id` to release the per-repo `asyncio.Lock` before `asyncio.sleep(exc.retry_after)`, preventing all concurrent callers from being blocked for up to 60s
- After sleep, re-acquires the lock with a double-check of `_thread_cache` (another caller may have succeeded during sleep)
- Added two concurrency tests proving the lock is released during sleep and the cache is checked after re-acquisition

Closes #42

## Test Plan

- [x] `test_resolve_thread_releases_lock_during_retry_sleep` — verifies concurrent callers aren't blocked during RetryAfter sleep
- [x] `test_resolve_thread_checks_cache_after_reacquire` — verifies cache is checked after re-acquiring lock post-sleep
- [x] All 25 topic tests pass
- [x] Full suite passes (459 tests, 2.76s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retry handling now releases locks during rate-limit backoff so other concurrent requests aren't blocked.
  * Cache checks added after backoff so redundant API calls are avoided when another caller succeeds.
  * Retry-interval fallback made explicit when rate-limit details are missing.

* **Tests**
  * Added async tests covering lock release during backoff and cache verification after reacquiring the lock.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->